### PR TITLE
chore: fix git repo URL in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "OpenAPI-Generator Contributors",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+    "url": "https://github.com/Cosmo-Tech/cosmotech-api-typescript-client.git"
   },
   "keywords": [
     "axios",


### PR DESCRIPTION
I'm not sure if this part of the package.json file is generated by the openapi generator, but the current pattern `GIT_USER_ID/GIT_REPO_ID.git` shows up in some tools & scripts parsing the package.json file so it'd be better to fix it :slightly_smiling_face: 

Based on git history, the git repo part was added in commit 47cab944. @sellisd do you know where it comes from?