### PR TITLE
Don't use yarn, use npm consistently

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,9 +12,8 @@ jobs:
       with:
         node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
-        scope: '@cosmotech' 
+        scope: '@cosmotech'
     - run: yarn
-    - run: git config --global user.email "vincent.carluer@cosmotech.com" && git config --global user.name "Vincent Carluer"
     - run: npm version ${{ github.event.release.tag_name }} --allow-same-version
     - run: npm publish
       env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
         node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
         scope: '@cosmotech'
-    - run: yarn
+    - run: npm install
     - run: npm version ${{ github.event.release.tag_name }} --allow-same-version
     - run: npm publish
       env:


### PR DESCRIPTION
We might want to move to yarn at some point to be consistent with the other frontend repositories, but at minima we need to be consistent _inside_ this one. In particular, the publish and SBOM generation should be done using the same tool to make sure we report the same dependency tree.